### PR TITLE
remove smol dep, so people can use this crate with tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smol = "1.2.5"
 tracing = "0.1.35"
 trillium = "0.2.2"
 


### PR DESCRIPTION
This crate looks great! Here's a quick suggestion, since it seems to build fine without a direct (non-dev) dependency on smol